### PR TITLE
fix compile error on linux, add cstring include

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 ._.DS_Store
+build*
+*.egg*

--- a/src/Record3DStream.cpp
+++ b/src/Record3DStream.cpp
@@ -2,6 +2,7 @@
 #include "JPEGDecoder.h"
 #include <lzfse.h>
 #include <usbmuxd.h>
+#include <cstring>
 #include <array>
 
 #define NTOHL_(n) (((((unsigned long)(n) & 0xFF)) << 24) | \


### PR DESCRIPTION
Record3DStream.cpp:147:13: error: ‘memcpy’ was not declared in this scope. note: ‘memcpy’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?