### PR TITLE
Ensured the processing thread has exited before releasing the LZ scratch buffer

### DIFF
--- a/src/Record3DStream.cpp
+++ b/src/Record3DStream.cpp
@@ -20,6 +20,8 @@ namespace Record3D
 
     Record3DStream::~Record3DStream()
     {
+        runloopThread_.join();
+        
         delete[] lzfseScratchBuffer_;
     }
 
@@ -70,7 +72,7 @@ namespace Record3D
                                       {
                                           StreamProcessingRunloop();
                                       } );
-        runloopThread_.detach();
+ 
         return true;
     }
 
@@ -240,8 +242,6 @@ namespace Record3D
 #endif
             }
         }
-
-        Disconnect();
     }
 
     uint8_t* Record3DStream::DecompressBuffer(const uint8_t* $compressedBuffer, size_t $compressedBufferSize, std::vector<uint8_t> &$destinationBuffer)


### PR DESCRIPTION
In Record3DStream destructor, the preallocated buffer for LZ decompression was destroyed without waiting for the processing thread to complete, i.e. the buffer was potentially still in use. This leads to crashes on Record3DStream destructions. This has been fixed by explicitely waiting for the thread to quit before destroying the buffer. For this I had to reverse the detachment of the thread to keep it joinable, I hope I did not missed something.