### PR TITLE
Fixes non-contiguous array resize

### DIFF
--- a/include/record3d/Record3DStream.h
+++ b/include/record3d/Record3DStream.h
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <functional>
 #include <string.h>
+#include <iostream>
 
 #ifdef PYTHON_BINDINGS_BUILD
 #include <pybind11/pybind11.h>
@@ -162,12 +163,11 @@ namespace Record3D
             size_t currentFrameHeight = currentFrameDepthHeight_;
 
             size_t bufferSize  = currentFrameWidth * currentFrameHeight * sizeof(float);
-            auto result        = py::array_t<float>(currentFrameWidth * currentFrameHeight);
+            auto result        = py::array_t<float>({static_cast<int>(currentFrameHeight), static_cast<int>(currentFrameWidth)});
             auto result_buffer = result.request();
             float *result_ptr  = (float *) result_buffer.ptr;
 
             std::memcpy(result_ptr, depthImageBuffer_.data(), bufferSize);
-            result.resize(std::vector<int>{static_cast<int>(currentFrameHeight), static_cast<int>(currentFrameWidth)});
 
             return result;
         }
@@ -183,12 +183,11 @@ namespace Record3D
             size_t currentFrameHeight = currentFrameConfidenceHeight_;
 
             size_t bufferSize  = currentFrameWidth * currentFrameHeight * sizeof(uint8_t);
-            auto result        = py::array_t<uint8_t>(currentFrameWidth * currentFrameHeight);
+            auto result        = py::array_t<uint8_t>({static_cast<int>(currentFrameHeight), static_cast<int>(currentFrameWidth)});
             auto result_buffer = result.request();
             uint8_t *result_ptr  = (uint8_t *) result_buffer.ptr;
 
             std::memcpy(result_ptr, confidenceImageBuffer_.data(), bufferSize);
-            result.resize(std::vector<int>{static_cast<int>(currentFrameHeight), static_cast<int>(currentFrameWidth)});
 
             return result;
         }
@@ -222,12 +221,11 @@ namespace Record3D
 
             constexpr int numChannels = 3;
             size_t bufferSize  = currentFrameWidth * currentFrameHeight * numChannels * sizeof(uint8_t);
-            auto result        = py::array_t<uint8_t>(bufferSize);
+            auto result        = py::array_t<uint8_t>({static_cast<int>(currentFrameHeight), static_cast<int>(currentFrameWidth), numChannels});
             auto result_buffer = result.request();
             uint8_t *result_ptr  = (uint8_t *) result_buffer.ptr;
 
             std::memcpy(result_ptr, RGBImageBuffer_.data(), bufferSize);
-            result.resize(std::vector<int>{static_cast<int>(currentFrameHeight), static_cast<int>(currentFrameWidth), numChannels});
 
             return result;
         }


### PR DESCRIPTION
When testing Record3D, the Record3DStream Python bindings threw an error related to trying to resize a non-contiguous array. 

I modified the declarations of the result arrays to have their sizes defined at instantiation and this seemed to fix the issue. The demo worked for me after this change.