### PR TITLE
Fixed compilation error

### DIFF
--- a/include/record3d/Record3DStructs.h
+++ b/include/record3d/Record3DStructs.h
@@ -2,6 +2,7 @@
 #define CPP_RECORD3DSTRUCTS_H
 
 #include <cstring>
+#include <string>
 
 namespace Record3D
 {


### PR DESCRIPTION
Fixed "include/record3d/Record3DStructs.h:33:21: error: field ‘udid’ has
incomplete type 'std::string'"
